### PR TITLE
[IMP] zen: add the verse countering ambiguity

### DIFF
--- a/zen.txt
+++ b/zen.txt
@@ -2,5 +2,6 @@ Beautiful is better than ugly.
 Simple is better than complexe.
 Complex is better than complicated.
 Readability counts.
+In the face of ambiguity, refuse the temptation to guess.
 
 The Zen of Python, by Tim Peters


### PR DESCRIPTION
Ambiguity causes miscommunication, lack of clarity, decision-making problems, legal and ethical issues, frustration, inefficiency, imprecise thinking and reduced trust.

That is why we need to add this verse, even the art of guessing is also misunderstood!