### PR TITLE
[IMP] zen: verse about ambiguity

### DIFF
--- a/zen.txt
+++ b/zen.txt
@@ -2,5 +2,6 @@ Beautiful is better than ugly.
 Simple is better than complexe.
 Complex is better than complicated.
 Readability counts.
+In the face of ambiguity, refuse the temptation to guess.
 
 The Zen of Python, by Tim Peters


### PR DESCRIPTION
Ambiguity in code can lead to misunderstandings and errors. The Zen of Python teaches us to refuse the temptation to guess when faced with unclear situations.

By striving for clarity and avoiding ambiguity, we ensure that our code remains robust, easier to maintain, and more understandable to others.