### PR TITLE
[FIX] zen: missing line about ambiguity

### DIFF
--- a/zen.txt
+++ b/zen.txt
@@ -2,5 +2,6 @@ Beautiful is better than ugly.
 Simple is better than complexe.
 Complex is better than complicated.
 Readability counts.
+In the face of ambiguity, refuse the temptation to guess.
 
 The Zen of Python, by Tim Peters


### PR DESCRIPTION
Issue
-----
When users read the zen poem, they miss important information which leads to an increase in bugfix tickets and a ~100% increase in adwi's groanings.

Steps to reproduce
-----
- Open the zen.txt file
- Read it out loud
- Contemplate your life choices

Cause
-----
The original author had a shitty day trying to find a bug in mrp. After hours of chasing stock_moves and stock_move_lines in his nightmares, he woke up, got drunk and wrote an uninteresting poem.

Ticket
-----
opw-420