### PR TITLE
[FIX] zen: wrong place for "readability"

### DIFF
--- a/zen.txt
+++ b/zen.txt
@@ -1,6 +1,6 @@
 Beautiful is better than ugly.
-Readability counts.
 Simple is better than complexe.
 Complex is better than complicated.
+Readability counts.
 
 The Zen of Python, by Tim Peters


### PR DESCRIPTION
The verse about readability was in the wrong place according to the original document at [PEP 20]. Now on, new entries should follow the same order as in the original document.

[PEP 20]: https://peps.python.org/pep-0020/