### PR TITLE
[IMP] zen: verses about ambuiguity and temptation

### DIFF
--- a/zen.txt
+++ b/zen.txt
@@ -2,5 +2,6 @@ Beautiful is better than ugly.
 Simple is better than complexe.
 Complex is better than complicated.
 Readability counts.
+In the face of ambiguity, refuse the temptation to guess.
 
 The Zen of Python, by Tim Peters


### PR DESCRIPTION
The Zen of Python is a collection of 19 aphorisms that capture the guiding principles behind Python’s design. You can display them anytime by running import this in a Python REPL. Tim Peters wrote them in 1999 as a joke, but they became an iconic part of Python culture that was even formalized as PEP 20.

task-1